### PR TITLE
Added disclaimer to motrix.

### DIFF
--- a/src/content/docs/guides/internet.mdx
+++ b/src/content/docs/guides/internet.mdx
@@ -52,7 +52,7 @@ Download managers are a piece of software which help you in downloading files fr
 
 <Tabs>
     <TabItem label="General Download Managers">
-        - ⭐ **[Motrix](https://motrix.app/)** - Modern download manager with torrent functionality.
+        - ⭐ **[Motrix](https://motrix.app/)** - Modern download manager with torrent functionality. <Badge text="The matrix extension for firefox is not working according to the reviews page." variant="caution" size="medium" />
         - 🖥️ [aria2](https://aria2.github.io/) - CLI download manager.
         - [GoSpeed](https://github.com/GopeedLab/gopeed) - Minimalistic download manager.
         - [pyLoad](https://pyload.net/) - Extremely lightweight download manager made with Python.


### PR DESCRIPTION
There are a lot of [reviews](https://addons.mozilla.org/en-US/firefox/addon/motrixwebextension/reviews/?score=1) claiming that the extension is broken on Firefox.