### PR TITLE
Updated official ublock url to the correct one

### DIFF
--- a/src/content/docs/guides/internet.mdx
+++ b/src/content/docs/guides/internet.mdx
@@ -34,7 +34,7 @@ import { Badge } from '@astrojs/starlight/components';
 
 <Tabs>
     <TabItem label="Browser Agnostic">
-        - ⭐ **[uBlock Origin](https://ublockorigin.com/)** - Most effective adblock for your browser. <Badge text="Do not use multiple adblocks at the same time!" variant="caution" size="medium" />
+        - ⭐ **[uBlock Origin](https://github.com/gorhill/uBlock/)** - Most effective adblock for your browser. <Badge text="Do not use multiple adblocks at the same time!" variant="caution" size="medium" />
         - ⭐ **[Dark Reader](https://darkreader.org/)** - Auto dark mode for websites.
         - [DuckDuckGo Privacy Essentials](https://duckduckgo.com/duckduckgo-help-pages/desktop/adding-duckduckgo-to-your-browser/) - Privacy essentials for your browser by DuckDuckGo
         - [Translate Web Pages](https://github.com/FilipePS/Traduzir-paginas-web) - Translate websites.


### PR DESCRIPTION
The url mention on the site is not the official one. The only official website is https://github.com/gorhill/uBlock/
[Source](https://www.reddit.com/r/uBlockOrigin/comments/z765l7/comment/iy4w3pk/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button)